### PR TITLE
Add method for querying container info

### DIFF
--- a/core/src/main/java/com/shazam/tocker/DockerInstance.java
+++ b/core/src/main/java/com/shazam/tocker/DockerInstance.java
@@ -65,6 +65,14 @@ public class DockerInstance {
         return dockerClient.getHost();
     }
 
+    public ContainerInfo getContainerInfo() {
+        try {
+            return dockerClient.inspectContainer(containerName);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public void run() {
         run(alwaysAlive());
     }


### PR DESCRIPTION
Since the configuration for the container might be different from that requested (if, for example, the container already exists), it would be helpful to be able to query the container for the configuration.

For example, I'm currently using this to create MySql containers for unit testing.  I'm mapping the 3306 port to 33060, but if I change the port in code, without removing the container, then even though I'm requesting a mapping to a different port, the container is already mapping to 33060.  It would be useful to ask the container which host port 3306 is currently mapped to, and use that.